### PR TITLE
fix(xxl-registry-client): 解析json - 对象字段名含有冒号的情况下解析不正确

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.xuxueli</groupId>
 	<artifactId>xxl-registry</artifactId>
-	<version>1.1.1-RC1</version>
+	<version>1.1.1-RC2</version>
 	<packaging>pom</packaging>
 
 	<name>${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.xuxueli</groupId>
 	<artifactId>xxl-registry</artifactId>
-	<version>1.1.1-SNAPSHOT</version>
+	<version>1.1.1-RC1</version>
 	<packaging>pom</packaging>
 
 	<name>${project.artifactId}</name>

--- a/xxl-registry-admin/pom.xml
+++ b/xxl-registry-admin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.xuxueli</groupId>
         <artifactId>xxl-registry</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.1-RC1</version>
     </parent>
     <artifactId>xxl-registry-admin</artifactId>
     <packaging>jar</packaging>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>com.xuxueli</groupId>
             <artifactId>xxl-registry-client</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>

--- a/xxl-registry-client/pom.xml
+++ b/xxl-registry-client/pom.xml
@@ -27,6 +27,27 @@
             <version>${slf4j-api.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+            <version>4.12</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+            <version>1.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/xxl-registry-client/pom.xml
+++ b/xxl-registry-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.xuxueli</groupId>
         <artifactId>xxl-registry</artifactId>
-        <version>1.1.1-RC1</version>
+        <version>1.1.1-RC2</version>
     </parent>
     <artifactId>xxl-registry-client</artifactId>
     <packaging>jar</packaging>

--- a/xxl-registry-client/pom.xml
+++ b/xxl-registry-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.xuxueli</groupId>
         <artifactId>xxl-registry</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.1-RC1</version>
     </parent>
     <artifactId>xxl-registry-client</artifactId>
     <packaging>jar</packaging>

--- a/xxl-registry-client/src/main/java/com/xxl/registry/client/XxlRegistryBaseClient.java
+++ b/xxl-registry-client/src/main/java/com/xxl/registry/client/XxlRegistryBaseClient.java
@@ -92,37 +92,42 @@ public class XxlRegistryBaseClient {
     }
 
     private Map<String, Object> requestAndValid(String pathUrl, String requestBody, int timeout){
-
-        for (String adminAddressUrl: adminAddressArr) {
-            String finalUrl = adminAddressUrl + pathUrl;
-
-            // request
-            String responseData = BasicHttpUtil.postBody(finalUrl, requestBody, timeout);
-            if (responseData == null) {
-                return null;
+        Map<String, Object> finalResult = null;
+        for (String adminAddressUrl : adminAddressArr) {
+            final String finalUrl = adminAddressUrl + pathUrl;
+            final Map<String, Object> resultTemp = request0(finalUrl, requestBody, timeout);
+            if (resultTemp != null) {
+                finalResult = resultTemp;
+                break;
             }
+        }
+        return finalResult;
+    }
 
-            // parse resopnse
-            Map<String, Object> resopnseMap = null;
-            try {
-                resopnseMap = BasicJson.parseMap(responseData);
-            } catch (Exception e) { }
-
-
-            // valid resopnse
-            if (resopnseMap==null
-                    || !resopnseMap.containsKey("code")
-                    || !"200".equals(String.valueOf(resopnseMap.get("code")))
-                    ) {
-                logger.warn("XxlRegistryBaseClient response fail, responseData={}", responseData);
-                return null;
-            }
-
-            return resopnseMap;
+    private Map<String, Object> request0(final String finalUrl, final String requestBody, final int timeout) {
+        // request
+        String responseData = BasicHttpUtil.postBody(finalUrl, requestBody, timeout);
+        if (responseData == null) {
+            return null;
         }
 
+        // parse resopnse
+        Map<String, Object> resopnseMap = null;
+        try {
+            resopnseMap = BasicJson.parseMap(responseData);
+        } catch (Exception e) { }
 
-        return null;
+
+        // valid resopnse
+        if (resopnseMap==null
+                || !resopnseMap.containsKey("code")
+                || !"200".equals(String.valueOf(resopnseMap.get("code")))
+                ) {
+            logger.warn("XxlRegistryBaseClient response fail, responseData={}", responseData);
+            return null;
+        }
+
+        return resopnseMap;
     }
 
     /**

--- a/xxl-registry-client/src/main/java/com/xxl/registry/client/util/json/DoubleQuotesTextExtractor.java
+++ b/xxl-registry-client/src/main/java/com/xxl/registry/client/util/json/DoubleQuotesTextExtractor.java
@@ -1,0 +1,70 @@
+package com.xxl.registry.client.util.json;
+
+/**
+ * an extractor to extract content quoted by a pair of double quotes from text
+ */
+public class DoubleQuotesTextExtractor {
+    private static final char DOUBLE_QUOTE = '"';
+    private static final char BACK_SLASH = '\\';
+
+    /**
+     * extract the content quoted by the first pair of double quotes.
+     * this means only one string would returned even the input contains more than one legal pairs of double quotes
+     *
+     * @param input text that may contains a pairs of double quotes
+     */
+    public ExtractedText extract(String input) {
+        final int[] leftRight = determineIndicesOfFirstDoubleQuotesPair(input);
+        return extractTextGivenStartEndIndicesOfDoubleQuotes(input, leftRight[0], leftRight[1]);
+    }
+
+    private int[] determineIndicesOfFirstDoubleQuotesPair(String input) {
+        int leftIndex = -1;
+        int rightIndex = -1;
+        Character prevChar = null;
+        for (int i = 0; i < input.length(); i++) {
+            final char curChar = input.charAt(i);
+            if (curChar == DOUBLE_QUOTE) {
+                if (prevChar == null || prevChar != BACK_SLASH) {
+                    if (leftIndex == -1) {
+                        leftIndex = i;
+                    } else {
+                        rightIndex = i;
+                    }
+                }
+            }
+            if (leftIndex != -1 && rightIndex != -1) {
+                break;
+            }
+            prevChar = curChar;
+        }
+        if (leftIndex == -1 || rightIndex == -1) {
+            throw new IllegalArgumentException(
+                String.format("input (%s) has wrong syntax, can not meet a right pair of double quotes", input)
+            );
+        }
+        return new int[]{leftIndex, rightIndex};
+    }
+
+    /**
+     * given a text input, extract content quoted by a pair of double quotes
+     *
+     * @param input      text contains a pair of double quotes
+     * @param leftIndex  index of left double quote
+     * @param rightIndex index of right double quote
+     */
+    private ExtractedText extractTextGivenStartEndIndicesOfDoubleQuotes(String input, int leftIndex, int rightIndex) {
+        if (input.charAt(leftIndex) != DOUBLE_QUOTE) {
+            throw new IllegalArgumentException(String.format("input (%s) not starts with \"", input));
+        }
+
+        if (input.charAt(rightIndex) != DOUBLE_QUOTE) {
+            throw new IllegalArgumentException(String.format("input (%s) not ends with \"", input));
+        }
+
+        final int startIdx = leftIndex + 1;
+        final int endIdx = rightIndex;
+        final String content = input.substring(startIdx, endIdx);
+        return new ExtractedText(content, startIdx, endIdx);
+    }
+}

--- a/xxl-registry-client/src/main/java/com/xxl/registry/client/util/json/ExtractedText.java
+++ b/xxl-registry-client/src/main/java/com/xxl/registry/client/util/json/ExtractedText.java
@@ -1,0 +1,25 @@
+package com.xxl.registry.client.util.json;
+
+public class ExtractedText {
+    private String content;
+    private int startIndex;
+    private int endIndex;
+
+    public ExtractedText(String content, int startIndex, int endIndex) {
+        this.content = content;
+        this.startIndex = startIndex;
+        this.endIndex = endIndex;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public int getStartIndex() {
+        return startIndex;
+    }
+
+    public int getEndIndex() {
+        return endIndex;
+    }
+}

--- a/xxl-registry-client/src/main/java/com/xxl/registry/client/util/json/JsonElement.java
+++ b/xxl-registry-client/src/main/java/com/xxl/registry/client/util/json/JsonElement.java
@@ -1,0 +1,19 @@
+package com.xxl.registry.client.util.json;
+
+class JsonElement {
+    private String key;
+    private Object value;
+
+    public JsonElement(String key, Object value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/xxl-registry-client/src/test/java/com/xxl/registry/client/test/util/json/BasicJsonReaderTest.java
+++ b/xxl-registry-client/src/test/java/com/xxl/registry/client/test/util/json/BasicJsonReaderTest.java
@@ -1,0 +1,43 @@
+package com.xxl.registry.client.test.util.json;
+
+import com.xxl.registry.client.util.json.BasicJsonReader;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class BasicJsonReaderTest {
+
+    @Test
+    public void parseMap_should_return_map_given_input_is_object_json() {
+        final BasicJsonReader reader = new BasicJsonReader();
+        final Map<String, Object> result = reader.parseMap("{\"goodsName\": \"这是商品\", \"id\": 123, \"price\": 0.52}");
+        assertThat(result.size(), is(3));
+        assertThat(result, Matchers.hasEntry("goodsName", (Object) "这是商品"));
+        assertThat((Long) result.get("id"), is(123L));
+        assertThat(result.get("price"), is((Object) 0.52D));
+    }
+
+    @Test
+    public void parseMap_should_return_map_given_input_is_object_json_with_a_string_field_value_contains_colon() {
+        final BasicJsonReader reader = new BasicJsonReader();
+        final Map<String, Object> result = reader.parseMap("{ \"id\": 123, \"price\": 0.52, \"goodsName\": \"hello:world\"}");
+        assertThat(result.size(), is(3));
+        assertThat(result, Matchers.hasEntry("goodsName", (Object) "hello:world"));
+        assertThat((Long) result.get("id"), is(123L));
+        assertThat(result.get("price"), is((Object) 0.52D));
+    }
+
+    @Test
+    public void parseMap_should_return_map_given_input_is_object_json_with_a_field_name_contains_colon() {
+        final BasicJsonReader reader = new BasicJsonReader();
+        final Map<String, Object> result = reader.parseMap("{ \"id\": 123, \"price\": 0.52, \"goods:Name\": \"hello-world\"}");
+        assertThat(result.size(), is(3));
+        assertThat(result, Matchers.hasEntry("goods:Name", (Object) "hello-world"));
+        assertThat((Long) result.get("id"), is(123L));
+        assertThat(result.get("price"), is((Object) 0.52D));
+    }
+}

--- a/xxl-registry-client/src/test/java/com/xxl/registry/client/test/util/json/DoubleQuotesTextExtractorTest.java
+++ b/xxl-registry-client/src/test/java/com/xxl/registry/client/test/util/json/DoubleQuotesTextExtractorTest.java
@@ -1,0 +1,85 @@
+package com.xxl.registry.client.test.util.json;
+
+import com.xxl.registry.client.util.json.DoubleQuotesTextExtractor;
+import com.xxl.registry.client.util.json.ExtractedText;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class DoubleQuotesTextExtractorTest {
+
+    @Test
+    public void extract_should_return_extracted_content_given_input_is_a_string_wrapped_with_a_pair_of_double_quotes() {
+        final String input = "\"hello-world\"";
+        final ExtractedText extractedText = new DoubleQuotesTextExtractor().extract(input);
+        assertThat(extractedText.getContent(), is("hello-world"));
+        assertThat(extractedText.getStartIndex(), is(1));
+        assertThat(extractedText.getEndIndex(), is(input.length() - 1));
+    }
+
+    @Test
+    public void extract_should_return_extracted_content_given_input_eq_a_pair_of_double_quotes(){
+        final ExtractedText extractedText = new DoubleQuotesTextExtractor().extract("\"\"");
+        assertThat(extractedText.getContent(), isEmptyString());
+        assertThat(extractedText.getStartIndex(), is(1));
+        assertThat(extractedText.getEndIndex(), is(1));
+    }
+
+    @Test
+    public void extract_should_return_extracted_content_given_input_contains_a_pair_of_double_quotes() {
+        final String input = "this is a\"hello-world\" string";
+        final ExtractedText extractedText = new DoubleQuotesTextExtractor().extract(input);
+        assertThat(extractedText.getContent(), is("hello-world"));
+        assertThat(extractedText.getStartIndex(), is(10));
+        assertThat(extractedText.getEndIndex(), is(21));
+    }
+
+    @Test
+    public void extract_should_return_extracted_content_given_input_contains_two_pairs_of_double_quotes() {
+        final String input = "this is a\"hello-world\" string \"goodJob\"";
+        final ExtractedText extractedText = new DoubleQuotesTextExtractor().extract(input);
+        assertThat(extractedText.getContent(), is("hello-world"));
+        assertThat(extractedText.getStartIndex(), is(10));
+        assertThat(extractedText.getEndIndex(), is(21));
+    }
+
+    @Test
+    public void extract_should_throw_exception_given_input_not_contains_a_pair_of_double_quotes(){
+        try {
+            new DoubleQuotesTextExtractor().extract("hello-world");
+            Assert.fail("expected to throw Exception");
+        }catch (Exception e){
+            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+        }
+
+        try {
+            new DoubleQuotesTextExtractor().extract("\"hello-world");
+            Assert.fail("expected to throw Exception");
+        }catch (Exception e){
+            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+        }
+
+        try {
+            new DoubleQuotesTextExtractor().extract("hello-world\"");
+            Assert.fail("expected to throw Exception");
+        }catch (Exception e){
+            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+        }
+
+        try {
+            new DoubleQuotesTextExtractor().extract("235\"hello-world");
+            Assert.fail("expected to throw Exception");
+        }catch (Exception e){
+            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+        }
+
+        try {
+            new DoubleQuotesTextExtractor().extract("hello-world\"356346");
+            Assert.fail("expected to throw Exception");
+        }catch (Exception e){
+            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+        }
+    }
+}


### PR DESCRIPTION
### 起因
xxl-mq项目里的Consumer topic命名需要用到冒号，但xxl-mq依赖的registry-client无法正常解析字段名含有冒号的json，导致服务发现dicovery的方法报错。

### 修改内容
对BasicJsonReader里parseMap的方法做修正，并且添加相关单元测试。